### PR TITLE
Hide sidebar when small mode and not home, decrease padding top for profile pic in big mode

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -301,7 +301,7 @@ a:active {
 
 .sidebar .logo-title {
     text-align: center;
-    padding-top: 240px;
+    padding-top: 120px;
     flex: 1;
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -188,6 +188,13 @@ a:active {
     margin-top: 60px;
 }
 
+.content_not_home {
+    height: auto;
+    float: right;
+    width: 60%;
+    margin-top: 60px;
+}
+
 .page-top {
     width: 60%;
     position: fixed;
@@ -261,6 +268,22 @@ a:active {
 }
 
 .sidebar {
+    width: 40%;
+    -webkit-background-size: cover;
+    background-size: cover;
+    background-color: var(--bg-color);
+    height: 100%;
+    top: 0;
+    left: 0;
+    position: fixed;
+    z-index: 4;
+    border-right: 1px solid var(--border-color);
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+}
+
+.sidebar_not_home {
     width: 40%;
     -webkit-background-size: cover;
     background-size: cover;
@@ -929,7 +952,18 @@ print {
         width: 100%;
         z-index: 2;
         position: relative;
-        margin-top: -1 * var(--navbar-burger-height);
+        margin-top: calc(0.1 * var(--navbar-burger-height));
+    }
+
+    .sidebar_not_home {
+        display: none;
+    }
+
+    .content_not_home {
+        width: 100%;
+        z-index: 2;
+        position: relative;
+        margin-top: calc( 1.5 * var(--navbar-burger-height));
     }
 
     .post figure.right {
@@ -1090,7 +1124,15 @@ print {
         padding-right: 25%;
         width: 35%;
     }
+    .content_not_home {
+        padding-right: 25%;
+        width: 35%;
+    }
     .sidebar {
+        padding-left: 15%;
+        width: 25%;
+    }
+    .sidebar_not_home {
         padding-left: 15%;
         width: 25%;
     }

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,15 +3,29 @@
 {{- partial "head.html" . -}}
 <body>
 
-{{- partial "sidebar.html" . -}}
-<div class="main">
-    {{ partial "navbar.html" . }}
-    <div class="autopagerize_page_element">
-        <div class="content">
-            {{- block "main" . }}{{- end }}
+{{ if .IsHome }}
+    {{- partial "sidebar.html" . -}}
+    <div class="main">
+        {{ partial "navbar.html" . }}
+        <div class="autopagerize_page_element">
+            <div class="content">
+                {{- block "main" . }}{{- end }}
+            </div>
         </div>
     </div>
-</div>
+{{ else }}
+    <div class="sidebar_not_home">
+        {{- partial "sidebar.html" . -}}
+    </div>
+    <div class="main">
+        {{ partial "navbar.html" . }}
+        <div class="autopagerize_page_element">
+            <div class="content_not_home">
+                {{- block "main" . }}{{- end }}
+            </div>
+        </div>
+    </div>
+{{- end -}}
 
 {{- partial "footer.html" . -}}
 {{- if (eq .Site.Params.simpleAnalytics.enable true) -}}


### PR DESCRIPTION
- Show the sidebar only when is not home.
- Reduce top padding for profile pic in big mode, so the social icons are visible even when screen is not full mode.